### PR TITLE
Fixed issue with URLs with existing parameters

### DIFF
--- a/src/variables/LanguageSwitcher.php
+++ b/src/variables/LanguageSwitcher.php
@@ -43,10 +43,11 @@ class LanguageSwitcherVariable
             $targetUrl = $languageService->getTargetUrl($language);
             
             if($targetUrl !== null) {
+                $separator = strpos($targetUrl,'?') !== false ? '&' : '?';
                 $languages[$language]['id'] = $language;
                 $languages[$language]['name'] = \Locale::getDisplayName($language, Craft::$app->language);
                 $languages[$language]['nativeName'] = \Locale::getDisplayName($language, $language);
-                $languages[$language]['url'] = $targetUrl . '?' . $queryParameterName . '=' . $language;
+                $languages[$language]['url'] = $targetUrl . $separator . $queryParameterName . '=' . $language;
             }
         }
         


### PR DESCRIPTION
language switcher fails when url parameter(s) already exists. It adds second `?` separator to URL – For example: `http://www.website.com?param=1?lang=en`... this small adjustments fixes the problem.